### PR TITLE
Update license copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The BSD Zero Clause License (0BSD)
 
-Copyright (c) 2020 Gatsby Inc.
+Copyright (c) 2017-2026 Andreas Maechler
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted.


### PR DESCRIPTION
Updates the LICENSE file copyright holder from Gatsby Inc. to Andreas Maechler and sets the year range to 2017-2026.