### PR TITLE
Clean up post-Astro-migration leftovers

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Install, build, and upload your site
         uses: withastro/action@v6
+        with:
+          node-version: 24
 
   deploy:
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,3 @@ pnpm-debug.log*
 
 # JetBrains
 .idea/
-
-# Gatsby files (legacy, remove after migration)
-.cache/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "dev": "astro dev",
     "build": "astro check && astro build",
     "check": "astro check",
-    "lint": "astro check",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "preview": "astro preview",

--- a/src/data/siteMetadata.js
+++ b/src/data/siteMetadata.js
@@ -9,7 +9,6 @@ export const site = {
     author: { name: "Andreas Maechler", summary: "who lives and works in Calgary." },
     social: {
         github: "amaechler",
-        linkedin: "andreasmaechler",
-        twitter: "amaechler"
+        linkedin: "andreasmaechler"
     }
 };

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -36,11 +36,6 @@ const metaDescription = description || site.description || author.summary;
         <meta property="og:type" content="website" />
         <meta property="og:url" content={canonicalUrl} />
 
-        <meta name="twitter:card" content="summary" />
-        <meta name="twitter:creator" content={social.twitter} />
-        <meta name="twitter:title" content={pageTitle} />
-        <meta name="twitter:description" content={metaDescription} />
-
         <link rel="icon" type="image/x-icon" href="/favicon.ico" />
         <link rel="alternate" type="application/rss+xml" title={title} href={rssUrl} />
     </head>


### PR DESCRIPTION
- Remove legacy Gatsby .cache/ entry from .gitignore
- Pin Node 24 in the Pages workflow to match engines/.mise
- Drop duplicate lint script (same as check)
- Remove unused Twitter handle and meta tags
