### PR TITLE
Repo improvements: CI on PRs, code consolidation, Shiki highlighting

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,6 +3,8 @@ name: GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -10,11 +12,34 @@ permissions:
   pages: write
   id-token: write
 
+# Allow only one concurrent deployment per ref. Cancel superseded PR builds,
+# but never cancel an in-progress production deployment.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.3
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check formatting
+        run: pnpm format:check
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +52,8 @@ jobs:
           node-version: 24
 
   deploy:
-    needs: build
+    if: github.event_name != 'pull_request'
+    needs: [build, format]
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -36,5 +62,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
-
-

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,7 +11,7 @@ export default defineConfig({
     site: site.siteUrl,
     integrations: [sitemap()],
     markdown: {
-        shikiConfig: { theme: "github-light" },
+        shikiConfig: { theme: "one-light" },
         remarkPlugins: [smartypants]
     }
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,15 +2,16 @@
 import { defineConfig } from "astro/config";
 import sitemap from "@astrojs/sitemap";
 import remarkSmartypants from "remark-smartypants";
+import { site } from "./src/data/siteMetadata";
 
 const smartypants = /** @type {any} */ (remarkSmartypants);
 
 // https://astro.build/config
 export default defineConfig({
-    site: "https://amaechler.com/",
+    site: site.siteUrl,
     integrations: [sitemap()],
     markdown: {
-        syntaxHighlight: "prism",
+        shikiConfig: { theme: "github-light" },
         remarkPlugins: [smartypants]
     }
 });

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
     "@astrojs/sitemap": "^3.7.3",
     "@fontsource/merriweather": "^5.2.11",
     "@fontsource/montserrat": "^5.2.8",
-    "astro": "^6.4.2",
+    "astro": "^6.4.5",
     "normalize.css": "^8.0.1",
     "remark-smartypants": "^3.0.2"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "lefthook": "^2.1.9",
-    "prettier": "^3.8.3",
+    "prettier": "^3.8.4",
     "prettier-plugin-astro": "^0.14.1",
     "sharp": "^0.34.5",
     "typescript": "^6.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       astro:
-        specifier: ^6.4.2
-        version: 6.4.2(@types/node@24.12.4)(rollup@4.61.1)(yaml@2.9.0)
+        specifier: ^6.4.5
+        version: 6.4.5(@types/node@24.13.1)(rollup@4.61.1)(yaml@2.9.0)
       normalize.css:
         specifier: ^8.0.1
         version: 8.0.1
@@ -32,13 +32,13 @@ importers:
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.9
-        version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@6.0.3)
+        version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@6.0.3)
       lefthook:
         specifier: ^2.1.9
         version: 2.1.9
       prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
+        specifier: ^3.8.4
+        version: 3.8.4
       prettier-plugin-astro:
         specifier: ^0.14.1
         version: 0.14.1
@@ -148,8 +148,8 @@ packages:
   '@emmetio/stream-reader@2.2.0':
     resolution: {integrity: sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+  '@emnapi/runtime@1.11.0':
+    resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -469,8 +469,8 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@nodable/entities@2.1.0':
-    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+  '@nodable/entities@2.1.1':
+    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -671,8 +671,8 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
-  '@types/node@24.12.4':
-    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
+  '@types/node@24.13.1':
+    resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
@@ -732,6 +732,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  anynum@1.0.0:
+    resolution: {integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -745,8 +748,8 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
-  astro@6.4.2:
-    resolution: {integrity: sha512-8H89CH2dKL5SCU99OCqdU9BGjmPkSJqaPurywj5XMo7eMFGUFD3vsNhdEKnEh4mK4LgGje3/QDTTSIIGst0G0Q==}
+  astro@6.4.5:
+    resolution: {integrity: sha512-0R7WLD1+WD/mTPcZxyKtcF0CztQi9ahFRtGM7oChJhxjNbr4lSBenxi+mk91k5bPTaUEoZ6edg1fDo2qP8bCwg==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -1381,8 +1384,8 @@ packages:
     resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
     engines: {node: ^14.15.0 || >=16.0.0}
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.8.4:
+    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -1485,13 +1488,8 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.8.2:
-    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1536,8 +1534,8 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strnum@2.3.0:
-    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+  strnum@2.4.0:
+    resolution: {integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==}
 
   suf-log@2.5.3:
     resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
@@ -1591,8 +1589,8 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -1819,14 +1817,24 @@ packages:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
 
+  vscode-jsonrpc@9.0.0:
+    resolution: {integrity: sha512-+VvMmQPJhtvJ+8O+zu2JKIRiLxXF8NW7krWgyMGeOHrp4Cn23T5hc0v2LknNeopDOB70wghHAds7mKtcZ0I4Sg==}
+    engines: {node: '>=14.0.0'}
+
   vscode-languageserver-protocol@3.17.5:
     resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-protocol@3.18.0:
+    resolution: {integrity: sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==}
 
   vscode-languageserver-textdocument@1.0.12:
     resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
 
   vscode-languageserver-types@3.17.5:
     resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver-types@3.18.0:
+    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
 
   vscode-languageserver@9.0.1:
     resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
@@ -1898,9 +1906,9 @@ packages:
 
 snapshots:
 
-  '@astrojs/check@0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@6.0.3)':
+  '@astrojs/check@0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@6.0.3)':
     dependencies:
-      '@astrojs/language-server': 2.16.10(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@6.0.3)
+      '@astrojs/language-server': 2.16.10(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@6.0.3)
       chokidar: 4.0.3
       kleur: 4.1.5
       typescript: 6.0.3
@@ -1924,7 +1932,7 @@ snapshots:
       smol-toml: 1.6.1
       unified: 11.0.5
 
-  '@astrojs/language-server@2.16.10(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@6.0.3)':
+  '@astrojs/language-server@2.16.10(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@6.0.3)':
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/yaml2ts': 0.2.4
@@ -1938,14 +1946,14 @@ snapshots:
       volar-service-css: 0.0.70(@volar/language-service@2.4.28)
       volar-service-emmet: 0.0.70(@volar/language-service@2.4.28)
       volar-service-html: 0.0.70(@volar/language-service@2.4.28)
-      volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@3.8.3)
+      volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@3.8.4)
       volar-service-typescript: 0.0.70(@volar/language-service@2.4.28)
       volar-service-typescript-twoslash-queries: 0.0.70(@volar/language-service@2.4.28)
       volar-service-yaml: 0.0.70(@volar/language-service@2.4.28)
       vscode-html-languageservice: 5.6.2
       vscode-uri: 3.1.0
     optionalDependencies:
-      prettier: 3.8.3
+      prettier: 3.8.4
       prettier-plugin-astro: 0.14.1
     transitivePeerDependencies:
       - typescript
@@ -2052,7 +2060,7 @@ snapshots:
 
   '@emmetio/stream-reader@2.2.0': {}
 
-  '@emnapi/runtime@1.10.0':
+  '@emnapi/runtime@1.11.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2223,7 +2231,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -2237,7 +2245,7 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@nodable/entities@2.1.0': {}
+  '@nodable/entities@2.1.1': {}
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -2384,13 +2392,13 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/node@24.12.4':
+  '@types/node@24.13.1':
     dependencies:
-      undici-types: 7.16.0
+      undici-types: 7.18.2
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.1
 
   '@types/unist@3.0.3': {}
 
@@ -2417,14 +2425,14 @@ snapshots:
       path-browserify: 1.0.1
       request-light: 0.7.0
       vscode-languageserver: 9.0.1
-      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-protocol: 3.18.0
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
   '@volar/language-service@2.4.28':
     dependencies:
       '@volar/language-core': 2.4.28
-      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-protocol: 3.18.0
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
@@ -2441,7 +2449,7 @@ snapshots:
       emmet: 2.4.11
       jsonc-parser: 2.3.1
       vscode-languageserver-textdocument: 1.0.12
-      vscode-languageserver-types: 3.17.5
+      vscode-languageserver-types: 3.18.0
       vscode-uri: 3.1.0
 
   '@vscode/l10n@0.0.18': {}
@@ -2468,6 +2476,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  anynum@1.0.0: {}
+
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
@@ -2476,7 +2486,7 @@ snapshots:
 
   array-iterate@2.0.1: {}
 
-  astro@6.4.2(@types/node@24.12.4)(rollup@4.61.1)(yaml@2.9.0):
+  astro@6.4.5(@types/node@24.13.1)(rollup@4.61.1)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.10.0
@@ -2516,7 +2526,7 @@ snapshots:
       piccolore: 0.1.3
       picomatch: 4.0.4
       rehype: 13.0.2
-      semver: 7.8.2
+      semver: 7.8.4
       shiki: 4.2.0
       smol-toml: 1.6.1
       svgo: 4.0.1
@@ -2528,8 +2538,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.5(@types/node@24.12.4)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.5(@types/node@24.12.4)(yaml@2.9.0))
+      vite: 7.3.5(@types/node@24.13.1)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@24.13.1)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -2762,10 +2772,10 @@ snapshots:
 
   fast-xml-parser@5.8.0:
     dependencies:
-      '@nodable/entities': 2.1.0
+      '@nodable/entities': 2.1.1
       fast-xml-builder: 1.2.0
       path-expression-matcher: 1.5.0
-      strnum: 2.3.0
+      strnum: 2.4.0
       xml-naming: 0.1.0
 
   fdir@6.5.0(picomatch@4.0.4):
@@ -3393,10 +3403,10 @@ snapshots:
   prettier-plugin-astro@0.14.1:
     dependencies:
       '@astrojs/compiler': 2.13.1
-      prettier: 3.8.3
+      prettier: 3.8.4
       sass-formatter: 0.7.9
 
-  prettier@3.8.3: {}
+  prettier@3.8.4: {}
 
   prismjs@1.30.0: {}
 
@@ -3558,15 +3568,13 @@ snapshots:
 
   sax@1.6.0: {}
 
-  semver@7.8.1: {}
-
-  semver@7.8.2: {}
+  semver@7.8.4: {}
 
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.8.1
+      semver: 7.8.4
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -3608,7 +3616,7 @@ snapshots:
 
   sitemap@9.0.1:
     dependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.1
       '@types/sax': 1.2.7
       arg: 5.0.2
       sax: 1.6.0
@@ -3636,7 +3644,9 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strnum@2.3.0: {}
+  strnum@2.4.0:
+    dependencies:
+      anynum: 1.0.0
 
   suf-log@2.5.3:
     dependencies:
@@ -3674,7 +3684,7 @@ snapshots:
 
   typescript-auto-import-cache@0.3.6:
     dependencies:
-      semver: 7.8.2
+      semver: 7.8.4
 
   typescript@6.0.3: {}
 
@@ -3684,7 +3694,7 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
-  undici-types@7.16.0: {}
+  undici-types@7.18.2: {}
 
   unified@11.0.5:
     dependencies:
@@ -3770,7 +3780,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.5(@types/node@24.12.4)(yaml@2.9.0):
+  vite@7.3.5(@types/node@24.13.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3779,13 +3789,13 @@ snapshots:
       rollup: 4.61.1
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.1
       fsevents: 2.3.3
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.5(@types/node@24.12.4)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@7.3.5(@types/node@24.13.1)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.5(@types/node@24.12.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@24.13.1)(yaml@2.9.0)
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
@@ -3812,12 +3822,12 @@ snapshots:
     optionalDependencies:
       '@volar/language-service': 2.4.28
 
-  volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@3.8.3):
+  volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@3.8.4):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
       '@volar/language-service': 2.4.28
-      prettier: 3.8.3
+      prettier: 3.8.4
 
   volar-service-typescript-twoslash-queries@0.0.70(@volar/language-service@2.4.28):
     dependencies:
@@ -3828,7 +3838,7 @@ snapshots:
   volar-service-typescript@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       path-browserify: 1.0.1
-      semver: 7.8.2
+      semver: 7.8.4
       typescript-auto-import-cache: 0.3.6
       vscode-languageserver-textdocument: 1.0.12
       vscode-nls: 5.2.0
@@ -3854,27 +3864,36 @@ snapshots:
     dependencies:
       '@vscode/l10n': 0.0.18
       vscode-languageserver-textdocument: 1.0.12
-      vscode-languageserver-types: 3.17.5
+      vscode-languageserver-types: 3.18.0
       vscode-uri: 3.1.0
 
   vscode-json-languageservice@4.1.8:
     dependencies:
       jsonc-parser: 3.3.1
       vscode-languageserver-textdocument: 1.0.12
-      vscode-languageserver-types: 3.17.5
+      vscode-languageserver-types: 3.18.0
       vscode-nls: 5.2.0
       vscode-uri: 3.1.0
 
   vscode-jsonrpc@8.2.0: {}
+
+  vscode-jsonrpc@9.0.0: {}
 
   vscode-languageserver-protocol@3.17.5:
     dependencies:
       vscode-jsonrpc: 8.2.0
       vscode-languageserver-types: 3.17.5
 
+  vscode-languageserver-protocol@3.18.0:
+    dependencies:
+      vscode-jsonrpc: 9.0.0
+      vscode-languageserver-types: 3.18.0
+
   vscode-languageserver-textdocument@1.0.12: {}
 
   vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver-types@3.18.0: {}
 
   vscode-languageserver@9.0.1:
     dependencies:
@@ -3905,12 +3924,12 @@ snapshots:
       '@vscode/l10n': 0.0.18
       ajv: 8.20.0
       ajv-draft-04: 1.0.0(ajv@8.20.0)
-      prettier: 3.8.3
+      prettier: 3.8.4
       request-light: 0.5.8
       vscode-json-languageservice: 4.1.8
       vscode-languageserver: 9.0.1
       vscode-languageserver-textdocument: 1.0.12
-      vscode-languageserver-types: 3.17.5
+      vscode-languageserver-types: 3.18.0
       vscode-uri: 3.1.0
       yaml: 2.7.1
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,28 +2,12 @@ import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 import { z } from "astro/zod";
 
-function toLocalDate(value: unknown): Date {
-    if (value instanceof Date) {
-        return new Date(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate());
-    }
-
-    if (typeof value === "string") {
-        const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-        if (match) {
-            const [, year, month, day] = match;
-            return new Date(parseInt(year, 10), parseInt(month, 10) - 1, parseInt(day, 10));
-        }
-    }
-
-    return new Date(value as string | number | Date);
-}
-
 const blog = defineCollection({
     loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
     schema: z.object({
         title: z.string(),
         description: z.string().optional(),
-        date: z.preprocess(toLocalDate, z.date())
+        date: z.coerce.date()
     })
 });
 

--- a/src/data/siteMetadata.ts
+++ b/src/data/siteMetadata.ts
@@ -1,10 +1,7 @@
-/**
- * Site configuration used across the application.
- * Extracted from the original gatsby-config.js siteMetadata.
- */
+/** Site configuration used across the application. */
 export const site = {
     title: "extralife",
-    description: "who lives and works in Calgary.",
+    description: "Personal blog of Andreas Maechler, who lives and works in Calgary.",
     siteUrl: "https://amaechler.com/",
     author: { name: "Andreas Maechler", summary: "who lives and works in Calgary." },
     social: {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,20 +2,20 @@
 import { site } from "../data/siteMetadata";
 import "../styles/global.css";
 
-const { title, author, social } = site;
-const { pathname } = Astro.url;
-const isRootPath = pathname === "/";
-const siteBase = Astro.site ?? Astro.url.origin;
-const canonicalUrl = new URL(pathname, siteBase).href;
-const rssUrl = new URL("/rss.xml", siteBase).href;
-
 interface Props {
     title: string;
     description?: string;
 }
 
-const { title: pageTitle, description } = Astro.props as Props;
-const metaDescription = description || site.description || author.summary;
+const { title, social } = site;
+const { pathname } = Astro.url;
+const isRootPath = pathname === "/";
+const canonicalUrl = new URL(pathname, site.siteUrl).href;
+const rssUrl = new URL("/rss.xml", site.siteUrl).href;
+const ogType = pathname.startsWith("/blog/") ? "article" : "website";
+
+const { title: pageTitle, description } = Astro.props;
+const metaDescription = description || site.description;
 ---
 
 <!doctype html>
@@ -33,9 +33,10 @@ const metaDescription = description || site.description || author.summary;
 
         <meta property="og:title" content={pageTitle} />
         <meta property="og:description" content={metaDescription} />
-        <meta property="og:type" content="website" />
+        <meta property="og:type" content={ogType} />
         <meta property="og:url" content={canonicalUrl} />
 
+        <link rel="canonical" href={canonicalUrl} />
         <link rel="icon" type="image/x-icon" href="/favicon.ico" />
         <link rel="alternate" type="application/rss+xml" title={title} href={rssUrl} />
     </head>
@@ -61,7 +62,7 @@ const metaDescription = description || site.description || author.summary;
                 © {new Date().getFullYear()}
                 {" | "}
                 <a href={`https://linkedin.com/in/${social.linkedin}`} target="_blank" rel="noopener noreferrer">
-                    Linkedin
+                    LinkedIn
                 </a>
                 {" | "}
                 <a href={`https://github.com/${social.github}`} target="_blank" rel="noopener noreferrer"> GitHub </a>

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,20 @@
+import { getCollection, type CollectionEntry } from "astro:content";
+
+/** All blog posts, newest first. */
+export async function getSortedPosts(): Promise<CollectionEntry<"blog">[]> {
+    const posts = await getCollection("blog");
+    return posts.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+}
+
+// Frontmatter dates are parsed as UTC midnight, so format them in UTC to
+// avoid the date shifting by one day depending on the build machine.
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC"
+});
+
+export function formatPostDate(date: Date): string {
+    return dateFormatter.format(date);
+}

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,41 +1,37 @@
 ---
 import Bio from "../../components/Bio.astro";
 import Layout from "../../layouts/Layout.astro";
-import { getCollection, render, type CollectionEntry } from "astro:content";
+import { render, type CollectionEntry } from "astro:content";
+import { formatPostDate, getSortedPosts } from "../../lib/posts";
 
 interface Props {
     post: CollectionEntry<"blog">;
+    previousPost: CollectionEntry<"blog"> | null;
+    nextPost: CollectionEntry<"blog"> | null;
 }
 
 export async function getStaticPaths() {
-    const posts = await getCollection("blog");
+    const posts = await getSortedPosts();
 
-    return posts.map(post => ({
+    return posts.map((post, index) => ({
         params: { slug: post.id },
-        props: { post }
+        props: {
+            post,
+            previousPost: posts[index + 1] ?? null,
+            nextPost: posts[index - 1] ?? null
+        }
     }));
 }
 
-const { post } = Astro.props as Props;
+const { post, previousPost, nextPost } = Astro.props;
 const { Content } = await render(post);
-
-const posts = (await getCollection("blog")).sort((a, b) => a.data.date.valueOf() - b.data.date.valueOf());
-const currentIndex = posts.findIndex(entry => entry.id === post.id);
-const previousPost = currentIndex > 0 ? posts[currentIndex - 1] : null;
-const nextPost = currentIndex >= 0 && currentIndex < posts.length - 1 ? posts[currentIndex + 1] : null;
-
-const dateFormatted = new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric"
-}).format(post.data.date);
 ---
 
 <Layout title={post.data.title} description={post.data.description}>
-    <article class="blog-post" itemscope itemtype="http://schema.org/Article">
+    <article class="blog-post" itemscope itemtype="https://schema.org/Article">
         <header>
             <h1 itemprop="headline">{post.data.title}</h1>
-            <p>{dateFormatted}</p>
+            <p>{formatPostDate(post.data.date)}</p>
         </header>
         <section itemprop="articleBody">
             <Content />
@@ -46,7 +42,7 @@ const dateFormatted = new Intl.DateTimeFormat("en-US", {
         </footer>
     </article>
     <nav class="blog-post-nav">
-        <ul style="display: flex; flex-wrap: wrap; justify-content: space-between; list-style: none; padding: 0;">
+        <ul>
             <li>
                 {
                     previousPost && (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,30 +1,28 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import Bio from "../components/Bio.astro";
-import { getCollection } from "astro:content";
+import { formatPostDate, getSortedPosts } from "../lib/posts";
 
-const posts = (await getCollection("blog")).sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
-
-const dateFormatter = new Intl.DateTimeFormat("en-US", { year: "numeric", month: "long", day: "numeric" });
+const posts = await getSortedPosts();
 ---
 
 <Layout title="All posts">
     <Bio />
     {
         posts.length === 0 ? (
-            <p>No blog posts found. Add markdown posts to "content/blog".</p>
+            <p>No blog posts found. Add markdown posts to "src/content/blog".</p>
         ) : (
-            <ol style="list-style: none;">
+            <ol class="post-list">
                 {posts.map(post => (
                     <li>
-                        <article class="post-list-item" itemscope itemtype="http://schema.org/Article">
+                        <article class="post-list-item" itemscope itemtype="https://schema.org/Article">
                             <header>
                                 <h2>
                                     <a href={`/blog/${post.id}/`} itemprop="url">
                                         <span itemprop="headline">{post.data.title}</span>
                                     </a>
                                 </h2>
-                                <small>{dateFormatter.format(post.data.date)}</small>
+                                <small>{formatPostDate(post.data.date)}</small>
                             </header>
                             <section>
                                 <p itemprop="description">{post.data.description ?? ""}</p>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,15 +1,15 @@
-import { getCollection } from "astro:content";
 import type { APIRoute } from "astro";
 import rss from "@astrojs/rss";
 import { site } from "../data/siteMetadata";
+import { getSortedPosts } from "../lib/posts";
 
-export const GET: APIRoute = async context => {
-    const posts = (await getCollection("blog")).sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+export const GET: APIRoute = async () => {
+    const posts = await getSortedPosts();
 
     return rss({
         title: site.title,
-        description: `${site.author.name} - ${site.author.summary}`,
-        site: context.site ?? site.siteUrl,
+        description: site.description,
+        site: site.siteUrl,
         items: posts.map(post => ({
             title: post.data.title,
             description: post.data.description ?? "",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -345,113 +345,14 @@ code {
     white-space: normal;
 }
 
-code[class*="language-"],
-pre[class*="language-"] {
-    word-wrap: normal;
-    background: none;
-    color: #000;
-    font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
-    font-size: 1em;
-    hyphens: none;
+pre.astro-code {
+    margin: 0 0 var(--spacing-8);
+    padding: 1em;
+    overflow-x: auto;
+    border: 1px solid var(--color-accent);
+    border-radius: 0.3em;
     line-height: 1.5;
     tab-size: 4;
-    text-align: left;
-    text-shadow: 0 1px #fff;
-    white-space: pre;
-    word-break: normal;
-    word-spacing: normal;
-}
-
-code[class*="language-"]::selection,
-code[class*="language-"] ::selection,
-pre[class*="language-"]::selection,
-pre[class*="language-"] ::selection {
-    background: #b3d4fc;
-    text-shadow: none;
-}
-
-pre[class*="language-"] {
-    margin: 0 0 var(--spacing-8);
-    overflow: auto;
-    padding: 1em;
-}
-
-:not(pre) > code[class*="language-"],
-pre[class*="language-"] {
-    background: #f5f2f0;
-}
-
-.token.cdata,
-.token.comment,
-.token.doctype,
-.token.prolog {
-    color: #708090;
-}
-
-.token.punctuation {
-    color: #999;
-}
-
-.token.namespace {
-    opacity: 0.7;
-}
-
-.token.boolean,
-.token.constant,
-.token.deleted,
-.token.number,
-.token.property,
-.token.symbol,
-.token.tag {
-    color: #905;
-}
-
-.token.attr-name,
-.token.builtin,
-.token.char,
-.token.inserted,
-.token.selector,
-.token.string {
-    color: #690;
-}
-
-.language-css .token.string,
-.style .token.string,
-.token.entity,
-.token.operator,
-.token.url {
-    background: hsla(0, 0%, 100%, 0.5);
-    color: #9a6e3a;
-}
-
-.token.atrule,
-.token.attr-value,
-.token.keyword {
-    color: #07a;
-}
-
-.token.class-name,
-.token.function {
-    color: #dd4a68;
-}
-
-.token.important,
-.token.regex,
-.token.variable {
-    color: #e90;
-}
-
-.token.bold,
-.token.important {
-    font-weight: 700;
-}
-
-.token.italic {
-    font-style: italic;
-}
-
-.token.entity {
-    cursor: help;
 }
 
 /* Media queries */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -268,6 +268,10 @@ a:focus {
     margin: 0;
 }
 
+.post-list {
+    list-style: none;
+}
+
 .post-list-item {
     margin-bottom: var(--spacing-8);
     margin-top: var(--spacing-8);
@@ -321,7 +325,12 @@ a:focus {
 }
 
 .blog-post-nav ul {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    list-style: none;
     margin: var(--spacing-0);
+    padding: var(--spacing-0);
 }
 
 code {


### PR DESCRIPTION
## Summary

A cleanup pass over the codebase, workflows, and dependencies.

### CI / workflow

- Build pull requests in CI (deploy job skipped for PRs) so changes get feedback before merge
- Add a format job running `prettier --check`, which previously never ran in CI
- Only cancel superseded PR builds; never cancel an in-progress production deploy, per GitHub's Pages guidance

### Code consolidation

- New `src/lib/posts.ts` with `getSortedPosts()` / `formatPostDate()`, replacing three divergent sort implementations and two duplicated date formatters
- Prev/next posts passed as props from `getStaticPaths` instead of re-fetching the collection
- Dates formatted in UTC, removing the `toLocalDate` preprocess hack from the content schema
- `siteMetadata` converted to TypeScript and made the single source of the site URL (imported by `astro.config.mjs`)

### SEO / accuracy fixes

- Real meta description for the homepage (was a sentence fragment)
- Add `rel=canonical`, use `og:type: article` on blog posts
- `https://schema.org` itemtypes, LinkedIn capitalization, inline styles moved into `global.css`

### Syntax highlighting

- Switch from Prism to Astro's default Shiki highlighter with the `one-light` theme; ~110 lines of hand-maintained Prism token CSS replaced by a single `pre.astro-code` rule
- Verified visually: code blocks render with a soft grey background and subtle border

### Dependencies

- astro 6.4.5, prettier 3.8.4, lefthook 2.1.9